### PR TITLE
Add Whisper benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,20 @@ git pull
 sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/phi-2-qa-with-context.py"
 ```
 
-## Benchmark
+## Benchmark LLM
 ```bash
 cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
 sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/transformers-llm-benchmark.py -s phi-2"
+```
+
+## Benchmark Whisper
+```bash
+cd ~
+git clone https://github.com/yf23/phi-2-test.git
+cd phi-2-test
+git pull
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3"
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/phi-2-qa-with-context.py"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/phi-2-qa-with-context.py"
 ```
 
 ## Benchmark LLM
@@ -15,7 +15,7 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/transformers-llm-benchmark.py -s phi-2"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/transformers-llm-benchmark.py -s phi-2"
 ```
 
 ## Benchmark Whisper
@@ -24,5 +24,5 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install git+https://github.com/huggingface/transformers && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip -r requirements.txt && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3-test"
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Quick Start
+## Quick Start on Phi-2
 Sample code from https://huggingface.co/microsoft/phi-2#sample-code
 
 ```bash
@@ -15,7 +15,7 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/transformers-llm-benchmark.py -s phi-2"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/transformers-llm-benchmark.py -s phi-2 && python /home/phi-2-test/transformers-llm-benchmark.py -s gpt2-xl"
 ```
 
 ## Benchmark Whisper

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip -r requirements.txt && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3-test"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3-test"
 ```

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ cd ~
 git clone https://github.com/yf23/phi-2-test.git
 cd phi-2-test
 git pull
-sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3-test"
+sudo docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -v ~/phi-2-test:/home/phi-2-test --workdir /home/phi-2-test nvcr.io/nvidia/pytorch:23.10-py3 /bin/bash -c "python -m pip install -r requirements.txt && python /home/phi-2-test/whisper-benchmark.py -s whisper-large-v3"
 ```

--- a/configs.py
+++ b/configs.py
@@ -42,13 +42,13 @@ WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
     "whisper-large-v3": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [8, 32, 64, 128, 256, 444],
-        "batch_size": [1, 8, 32, 64, 128, 256],
+        "batch_size": [1, 8, 32, 64, 128, 192],
         "n_iterations": 5,
     },
     "whisper-large-v3-test": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [444],
-        "batch_size": [256],
+        "batch_size": [192],
         "n_iterations": 1,
     },
 }

--- a/configs.py
+++ b/configs.py
@@ -1,4 +1,4 @@
-PERF_BENCHMARK_CONFIG_DICT = {
+LLM_PERF_BENCHMARK_CONFIG_DICT = {
     "phi-2": {
         "model_name": "microsoft/phi-2",
         "input_token_length": [32, 256, 1024, 2048],
@@ -30,6 +30,36 @@ LLM_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS = [
     "model_loading_latency",
     "tokenizer_loading_latency",
     "input_tokenization_latency",
+    "output_decoding_latency",
+    "first_token_latency",
+    "generation_latency",
+    "total_latency",
+    "throughput_e2e",
+    "throughput_generation",
+]
+
+WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
+    "whisper-large-v3": {
+        "model_name": "openai/whisper-large-v3",
+        "output_token_length": [8, 32, 64, 128, 256, 448],
+        "batch_size": [1, 8, 32, 64, 128, 256, 512, 1024],
+        "n_iterations": 5,
+    },
+    "whisper-large-v3-test": {
+        "model_name": "openai/whisper-large-v3",
+        "output_token_length": [448],
+        "batch_size": [1024],
+        "n_iterations": 1,
+    },
+}
+
+WHISPER_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS = [
+    "model_name",
+    "output_token_length",
+    "batch_size",
+    "model_loading_latency",
+    "processsor_loading_latency",
+    "input_processing_latency",
     "output_decoding_latency",
     "first_token_latency",
     "generation_latency",

--- a/configs.py
+++ b/configs.py
@@ -42,13 +42,13 @@ WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
     "whisper-large-v3": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [8, 32, 64, 128, 256, 448],
-        "batch_size": [1, 8, 32, 64, 128, 256, 512, 1024],
+        "batch_size": [1, 8, 32, 64, 128, 256],
         "n_iterations": 5,
     },
     "whisper-large-v3-test": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [448],
-        "batch_size": [512],
+        "batch_size": [256],
         "n_iterations": 1,
     },
 }

--- a/configs.py
+++ b/configs.py
@@ -48,7 +48,7 @@ WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
     "whisper-large-v3-test": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [448],
-        "batch_size": [1024],
+        "batch_size": [512],
         "n_iterations": 1,
     },
 }

--- a/configs.py
+++ b/configs.py
@@ -41,13 +41,13 @@ LLM_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS = [
 WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
     "whisper-large-v3": {
         "model_name": "openai/whisper-large-v3",
-        "output_token_length": [8, 32, 64, 128, 256, 448],
+        "output_token_length": [8, 32, 64, 128, 256, 444],
         "batch_size": [1, 8, 32, 64, 128, 256],
         "n_iterations": 5,
     },
     "whisper-large-v3-test": {
         "model_name": "openai/whisper-large-v3",
-        "output_token_length": [448],
+        "output_token_length": [444],
         "batch_size": [256],
         "n_iterations": 1,
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+transformers @ git+https://github.com/huggingface/transformers
+datasets

--- a/transformers-llm-benchmark.py
+++ b/transformers-llm-benchmark.py
@@ -4,7 +4,7 @@ import torch
 import argparse
 import transformers
 from utils import ThroughputStreamer, write_csv_file
-from configs import PERF_BENCHMARK_CONFIG_DICT, LLM_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS
+from configs import LLM_PERF_BENCHMARK_CONFIG_DICT, LLM_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
@@ -15,7 +15,7 @@ def parse_args():
         "--test-scenario",
         type=str,
         default="phi-2",
-        choices=PERF_BENCHMARK_CONFIG_DICT.keys(),
+        choices=LLM_PERF_BENCHMARK_CONFIG_DICT.keys(),
         help="Test scenario to run",
     )
     return parser.parse_args()
@@ -216,11 +216,11 @@ def run_all_benchmark(test_scenario):
     )
 
     # Read config
-    model_name = PERF_BENCHMARK_CONFIG_DICT[test_scenario]["model_name"]
-    input_token_length_list = PERF_BENCHMARK_CONFIG_DICT[test_scenario]["input_token_length"]
-    output_token_length_list = PERF_BENCHMARK_CONFIG_DICT[test_scenario]["output_token_length"]
-    batch_size_list = PERF_BENCHMARK_CONFIG_DICT[test_scenario]["batch_size"]
-    n_iterations = PERF_BENCHMARK_CONFIG_DICT[test_scenario]["n_iterations"]
+    model_name = LLM_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["model_name"]
+    input_token_length_list = LLM_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["input_token_length"]
+    output_token_length_list = LLM_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["output_token_length"]
+    batch_size_list = LLM_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["batch_size"]
+    n_iterations = LLM_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["n_iterations"]
 
     # Warm up
     run_model(model_name, ["Get Ready"], 2, 1)

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -73,6 +73,7 @@ def run_model(
         min_new_tokens=output_token_length,
         max_new_tokens=output_token_length,
         streamer=streamer,
+        language='en'
     )
     time_end_generation = time.perf_counter()
     streamer.set_latencies(time_start_generation, time_end_generation)

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -1,11 +1,11 @@
 import gc
 import time
 import torch
+import argparse
 import transformers
-from datasets import load_dataset
-from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, TextStreamer
-
-BaseStreamer = TextStreamer.__bases__[0]
+from utils import ThroughputStreamer, write_csv_file
+from configs import PERF_BENCHMARK_CONFIG_DICT, LLM_PERF_BENCHMARK_OUTPUT_CSV_COLUMNS
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
 
 
 MODEL_NAME = "openai/whisper-large-v3"
@@ -15,52 +15,6 @@ BATCH_SIZE_LIST = [1, 8, 32, 64]
 N_ITERATIONS = 5
 
 
-class ThroughputStreamer(BaseStreamer):
-    def __init__(self):
-        self.first_token_time = -1
-        self.last_token_time = -1
-        self.skip_prompt = True
-        self.n_tokens = 0
-        self.tot_latency = -1
-        self.ftl = -1
-
-    def put(self, value):
-        # Prompt tokens sent first, ignore
-        if self.skip_prompt:
-            self.skip_prompt = False
-            return
-
-        if self.first_token_time == -1:
-            self.first_token_time = time.perf_counter()
-
-        self.n_tokens += len(value.flatten())
-
-    def end(self):
-        self.last_token_time = time.perf_counter()
-
-    def generation_latency(self):
-        return self.last_token_time - self.first_token_time
-
-    def set_latencies(self, pre_generate_start_time, post_generate_end_time):
-        self.ftl = self.first_token_time - pre_generate_start_time
-        self.tot_latency = post_generate_end_time - pre_generate_start_time
-
-    def first_token_latency(self):
-        return self.ftl
-
-    def throughput(self):
-        return self.n_tokens / self.generation_latency()
-
-    def total_latency(self):
-        return self.tot_latency
-
-
-def write_csv_file(line, filepath, append=True):
-    mode = "a" if append else "w"
-    with open(filepath, mode) as f:
-        f.write(line + "\n")
-
-
 def run_model(
     model_name,
     batch_waveform,
@@ -68,10 +22,12 @@ def run_model(
     output_token_length,
 ):
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
-    
+
     # Load the model
     time_start_model_loading = time.perf_counter()
-    model = AutoModelForSpeechSeq2Seq.from_pretrained(model_name, torch_dtype="auto").to(device)
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(
+        model_name, torch_dtype="auto"
+    ).to(device)
     time_end_model_loading = time.perf_counter()
     time_model_loading = time_end_model_loading - time_start_model_loading
 

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -32,7 +32,7 @@ def run_model(
     sampling_rate,
     output_token_length,
 ):
-    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    device = "cuda:0"
 
     # Load the model
     time_start_model_loading = time.perf_counter()
@@ -267,6 +267,16 @@ def run_all_benchmark(test_scenario):
 
 
 if __name__ == "__main__":
+    # Check CUDA availability
+    if not torch.cuda.is_available():
+        print("CUDA is not available. Exiting.")
+        exit()
+
+    # Set logging verbosity
     transformers.logging.set_verbosity_error()
+
+    # Parse arguments
     args = parse_args()
+
+    # Run benchmark
     run_all_benchmark(args.test_scenario)

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -63,9 +63,6 @@ def run_model(
     time_processing = time_end_processing - time_start_processing
 
     # Generate output
-    print("Model's dtype: ", model.dtype)
-    print("Input features' dtype: ", input_features["input_features"].dtype)
-
     streamer = ThroughputStreamer()
     time_start_generation = time.perf_counter()
     outputs = model.generate(
@@ -73,7 +70,7 @@ def run_model(
         min_new_tokens=output_token_length,
         max_new_tokens=output_token_length,
         streamer=streamer,
-        language='en'
+        language="en",
     )
     time_end_generation = time.perf_counter()
     streamer.set_latencies(time_start_generation, time_end_generation)

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -37,7 +37,7 @@ def run_model(
     # Load the model
     time_start_model_loading = time.perf_counter()
     model = AutoModelForSpeechSeq2Seq.from_pretrained(
-        model_name, trust_remote_code=True
+        model_name, trust_remote_code=True, torch_dtype="auto"
     ).to(device)
     time_end_model_loading = time.perf_counter()
     time_model_loading = time_end_model_loading - time_start_model_loading

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -242,7 +242,7 @@ def run_all_benchmark(test_scenario):
     n_iterations = WHISPER_PERF_BENCHMARK_CONFIG_DICT[test_scenario]["n_iterations"]
 
     # Warm up
-    run_model(model_name, np.random.normal(0, 0.5, 93680), 16000, 8)
+    # run_model(model_name, np.random.normal(0, 0.5, 93680), 16000, 8)
 
     # Run benchmarks
     for output_token_length in output_token_length_list:

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -33,10 +33,6 @@ def run_model(
     output_token_length,
 ):
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
-    if model_name == "openai/whisper-large-v3" and torch.cuda.is_available():
-        torch_dtype = torch.float16
-    else:
-        torch_dtype = torch.float32
 
     # Load the model
     time_start_model_loading = time.perf_counter()
@@ -60,13 +56,16 @@ def run_model(
             sampling_rate=sampling_rate,
             return_tensors="pt",
         )
-        .to(torch_dtype)
+        .to(model.dtype)
         .to(device)
     )
     time_end_processing = time.perf_counter()
     time_processing = time_end_processing - time_start_processing
 
     # Generate output
+    print("Model's dtype: ", model.dtype)
+    print("Input features' dtype: ", input_features["input_values"].dtype)
+
     streamer = ThroughputStreamer()
     time_start_generation = time.perf_counter()
     outputs = model.generate(

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -64,7 +64,7 @@ def run_model(
 
     # Generate output
     print("Model's dtype: ", model.dtype)
-    print("Input features' dtype: ", input_features["input_values"].dtype)
+    print("Input features' dtype: ", input_features["input_features"].dtype)
 
     streamer = ThroughputStreamer()
     time_start_generation = time.perf_counter()

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -1,0 +1,290 @@
+import gc
+import time
+import torch
+import transformers
+from datasets import load_dataset
+from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, TextStreamer
+
+BaseStreamer = TextStreamer.__bases__[0]
+
+
+MODEL_NAME = "openai/whisper-large-v3"
+# INPUT_TOKEN_LENGTH_LIST = [32, 256, 512]
+OUTPUT_TOKEN_LENGTH_LIST = [1, 32, 64, 256]
+BATCH_SIZE_LIST = [1, 8, 32, 64]
+N_ITERATIONS = 5
+
+
+class ThroughputStreamer(BaseStreamer):
+    def __init__(self):
+        self.first_token_time = -1
+        self.last_token_time = -1
+        self.skip_prompt = True
+        self.n_tokens = 0
+        self.tot_latency = -1
+        self.ftl = -1
+
+    def put(self, value):
+        # Prompt tokens sent first, ignore
+        if self.skip_prompt:
+            self.skip_prompt = False
+            return
+
+        if self.first_token_time == -1:
+            self.first_token_time = time.perf_counter()
+
+        self.n_tokens += len(value.flatten())
+
+    def end(self):
+        self.last_token_time = time.perf_counter()
+
+    def generation_latency(self):
+        return self.last_token_time - self.first_token_time
+
+    def set_latencies(self, pre_generate_start_time, post_generate_end_time):
+        self.ftl = self.first_token_time - pre_generate_start_time
+        self.tot_latency = post_generate_end_time - pre_generate_start_time
+
+    def first_token_latency(self):
+        return self.ftl
+
+    def throughput(self):
+        return self.n_tokens / self.generation_latency()
+
+    def total_latency(self):
+        return self.tot_latency
+
+
+def write_csv_file(line, filepath, append=True):
+    mode = "a" if append else "w"
+    with open(filepath, mode) as f:
+        f.write(line + "\n")
+
+
+def run_model(
+    model_name,
+    batch_waveform,
+    sampling_rate,
+    output_token_length,
+):
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    
+    # Load the model
+    time_start_model_loading = time.perf_counter()
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(model_name, torch_dtype="auto").to(device)
+    time_end_model_loading = time.perf_counter()
+    time_model_loading = time_end_model_loading - time_start_model_loading
+
+    # Load the processor
+    time_start_processor_loading = time.perf_counter()
+    processor = AutoProcessor.from_pretrained(model_name)
+    time_end_processor_loading = time.perf_counter()
+    time_processor_loading = time_end_processor_loading - time_start_processor_loading
+
+    # Process prompt
+    time_start_processing = time.perf_counter()
+    input_features = processor(
+        batch_waveform,
+        sampling_rate=sampling_rate,
+        return_tensors="pt",
+    ).to(device)
+    time_end_processing = time.perf_counter()
+    time_processing = time_end_processing - time_start_processing
+
+    # Generate output
+    streamer = ThroughputStreamer()
+    time_start_generation = time.perf_counter()
+    outputs = model.generate(
+        **input_features,
+        min_new_tokens=output_token_length,
+        max_new_tokens=output_token_length,
+        streamer=streamer,
+    )
+    time_end_generation = time.perf_counter()
+    streamer.set_latencies(time_start_generation, time_end_generation)
+    time_first_token_latency = streamer.first_token_latency()
+    time_generation = streamer.generation_latency()
+    throughput = streamer.throughput()
+
+    # Decode output
+    time_start_decoding = time.perf_counter()
+    processor.batch_decode(outputs, skip_special_tokens=True)
+    time_end_decoding = time.perf_counter()
+    time_decoding = time_end_decoding - time_start_decoding
+
+    # Clean up memory
+    del model
+    del processor
+    del input_features
+    del outputs
+    time.sleep(10)
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return (
+        time_model_loading,
+        time_processor_loading,
+        time_processing,
+        time_first_token_latency,
+        time_generation,
+        throughput,
+        time_decoding,
+    )
+
+
+def run_benchmark(
+    model_name,
+    input_token_length,
+    output_token_length,
+    batch_size,
+    n_iter,
+    input_text="",
+    verbose_run=False,
+    verbose_summary=True,
+):
+    # Print parameters in one line
+    if verbose_summary:
+        print(
+            f"{model_name}: input_len={input_token_length}, output_len={output_token_length}, batch_size={batch_size}"
+        )
+
+    # Benchmark time placeholder
+    time_model_loading_list = []
+    time_tokenizer_loading_list = []
+    time_tokenization_list = []
+    time_first_token_latency_list = []
+    time_generation_list = []
+    time_e2e_list = []
+    throughput_e2e_list = []
+    throughput_generation_list = []
+
+    # Input text
+    text = "Briefly summarize about the difference between NC and NCC H100 v5 VMs."
+    if input_text:
+        text = input_text
+    prompt = " ".join([text for _ in range(500)])
+
+    # Make batch
+    batch_prompt = [prompt for _ in range(batch_size)]
+
+    # Start benchmarking
+    for _ in range(n_iter):
+        if verbose_run:
+            print(f"ITERATION: {_+1}/{n_iter}")
+
+        # Run benchmark
+        (
+            time_model_loading,
+            time_tokenizer_loading,
+            time_tokenization,
+            time_first_token_latency,
+            time_generation,
+            throughput_generation,
+            time_decoding,
+        ) = run_model(model_name, batch_prompt, input_token_length, output_token_length)
+        time_model_loading_list.append(time_model_loading)
+        time_tokenizer_loading_list.append(time_tokenizer_loading)
+        time_tokenization_list.append(time_tokenization)
+        time_first_token_latency_list.append(time_first_token_latency)
+        time_generation_list.append(time_generation)
+
+        # Calculate end to end time
+        time_e2e = time_tokenization + time_first_token_latency + time_generation
+        time_e2e_list.append(time_e2e)
+
+        throughput_generation_list.append(throughput_generation)
+        throughput_e2e = batch_size * output_token_length / time_e2e
+        throughput_e2e_list.append(throughput_e2e)
+
+        # Report
+        if verbose_run:
+            print(f"\tEnd to end time: {time_e2e}")
+            print(f"\t\tModel loading time: {time_model_loading} seconds")
+            print(f"\t\tTokenizer loading time: {time_tokenizer_loading} seconds")
+            print(f"\t\tTokenization time: {time_tokenization} seconds")
+            print(f"\t\tFirst token latency: {time_first_token_latency} seconds")
+            print(f"\t\tGeneration time: {time_generation} seconds")
+            print(f"\tThroughput (e2e): {throughput_e2e} tokens/second")
+            print(f"\tThroughput (generation): {throughput_generation} tokens/second")
+
+    # Calculate average
+    time_e2e_avg = sum(time_e2e_list) / n_iter
+    time_model_loading_avg = sum(time_model_loading_list) / n_iter
+    time_tokenizer_loading_avg = sum(time_tokenizer_loading_list) / n_iter
+    time_tokenization_avg = sum(time_tokenization_list) / n_iter
+    time_first_token_latency_avg = sum(time_first_token_latency_list) / n_iter
+    time_generation_avg = sum(time_generation_list) / n_iter
+    throughput_e2e_avg = sum(throughput_e2e_list) / n_iter
+    throughput_generation_avg = sum(throughput_generation_list) / n_iter
+
+    # Print summary benchmark results
+    if verbose_summary:
+        if verbose_run:
+            print("\n\nSUMMARY BENCHMARK RESULTS")
+        print(f"\tEnd to end time: {time_e2e_avg} seconds")
+        print(f"\t\tModel loading time: {time_model_loading_avg} seconds")
+        print(f"\t\tTokenizer loading time: {time_tokenizer_loading_avg} seconds")
+        print(f"\t\tTokenization time: {time_tokenization_avg} seconds")
+        print(f"\t\tFirst token latency: {time_first_token_latency_avg} seconds")
+        print(f"\t\tGeneration time: {time_generation_avg} seconds")
+        print(f"\tThroughput (e2e): {throughput_e2e_avg} tokens/second")
+        print(f"\tThroughput (generation): {throughput_generation_avg} tokens/second")
+        print("\n\n")
+
+    return (
+        time_model_loading_avg,
+        time_tokenizer_loading_avg,
+        time_tokenization_avg,
+        time_first_token_latency_avg,
+        time_generation_avg,
+        time_e2e_avg,
+        throughput_e2e_avg,
+        throughput_generation_avg,
+    )
+
+
+if __name__ == "__main__":
+    transformers.logging.set_verbosity_error()
+
+    # Write header to CSV
+    columns = [
+        "model_name",
+        "input_token_length",
+        "output_token_length",
+        "batch_size",
+        "model_loading_latency",
+        "tokenizer_loading_latency",
+        "tokenization_latency",
+        "first_token_latency",
+        "generation_latency",
+        "total_latency",
+        "throughput_e2e",
+        "throughput_generation",
+    ]
+    result_csv_filepath = (
+        f'{MODEL_NAME.split("/")[-1]}_perf_data_{time.strftime("%Y%m%d%H%M%S")}.csv'
+    )
+    write_csv_file(
+        ",".join(columns),
+        result_csv_filepath,
+        append=False,
+    )
+
+    # Warm up
+    run_model(MODEL_NAME, ["Get Ready"], 2, 1)
+
+    # Run benchmarks
+    for input_token_length in INPUT_TOKEN_LENGTH_LIST:
+        for output_token_length in OUTPUT_TOKEN_LENGTH_LIST:
+            for batch_size in BATCH_SIZE_LIST:
+                results = run_benchmark(
+                    MODEL_NAME,
+                    input_token_length,
+                    output_token_length,
+                    batch_size,
+                    N_ITERATIONS,
+                )
+                write_csv_file(
+                    f"{MODEL_NAME},{input_token_length},{output_token_length},{batch_size},{','.join(map(str, results))}",
+                    result_csv_filepath,
+                )

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -260,7 +260,6 @@ def run_all_benchmark(test_scenario):
 
 
 if __name__ == "__main__":
-    torch.set_default_device("cuda")
     transformers.logging.set_verbosity_error()
     args = parse_args()
     run_all_benchmark(args.test_scenario)


### PR DESCRIPTION
This pull request includes significant changes to the benchmarking setup for the project. The changes primarily focus on adding support for benchmarking the Whisper model, in addition to the existing Phi-2 and LLM models. The most important changes are:

1. `README.md`: The Quick Start and Benchmark sections have been updated to reflect the changes in the Docker commands and the addition of the Whisper benchmark.
2. `configs.py`: The configuration dictionary for the performance benchmark has been renamed to `LLM_PERF_BENCHMARK_CONFIG_DICT` and a new configuration dictionary `WHISPER_PERF_BENCHMARK_CONFIG_DICT` has been added for the Whisper benchmark. [[1]](diffhunk://#diff-c5d13c0f25b00c1ced8b97504fcadf314555c353092b9b584aeda64a108f7237L1-R1) [[2]](diffhunk://#diff-c5d13c0f25b00c1ced8b97504fcadf314555c353092b9b584aeda64a108f7237R40-R69)
3. `transformers-llm-benchmark.py`: The script has been updated to import the renamed configuration dictionary `LLM_PERF_BENCHMARK_CONFIG_DICT` and use it in the `parse_args` and `run_all_benchmark` functions. [[1]](diffhunk://#diff-d0aef6621200c0cf83dd1c4596e9c727a8c0292ce56ac9de2c0a11949115a45eL7-R7) [[2]](diffhunk://#diff-d0aef6621200c0cf83dd1c4596e9c727a8c0292ce56ac9de2c0a11949115a45eL18-R18) [[3]](diffhunk://#diff-d0aef6621200c0cf83dd1c4596e9c727a8c0292ce56ac9de2c0a11949115a45eL219-R223)
4. `whisper-benchmark.py`: A new benchmarking script has been added for the Whisper model. This script includes functions to parse arguments, run the model, run the benchmark, and run all benchmarks for the Whisper model.