### PR TITLE
Add support to use customized audio file in Whisper benchmarking

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -48,7 +48,7 @@ WHISPER_PERF_BENCHMARK_CONFIG_DICT = {
     "whisper-large-v3-test": {
         "model_name": "openai/whisper-large-v3",
         "output_token_length": [444],
-        "batch_size": [192],
+        "batch_size": [2],
         "n_iterations": 1,
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 transformers @ git+https://github.com/huggingface/transformers
 datasets
+pydub
+librosa

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -75,6 +75,7 @@ def run_model(
     batch_waveform,
     sampling_rate,
     output_token_length,
+    verbose_output=False,
 ):
     device = "cuda:0"
 
@@ -124,9 +125,10 @@ def run_model(
 
     # Decode output
     time_start_output_decoding = time.perf_counter()
-    processor.batch_decode(outputs)
+    decoded_outputs = processor.batch_decode(outputs, skip_special_tokens=True)
     time_end_output_decoding = time.perf_counter()
-    print(processor.batch_decode(outputs), end="\n\n")
+    if verbose_output:
+        print(decoded_outputs, end="\n\n")
     time_output_decoding = time_end_output_decoding - time_start_output_decoding
 
     # Clean up memory
@@ -134,6 +136,7 @@ def run_model(
     del processor
     del input_features
     del outputs
+    del decoded_outputs
     time.sleep(10)
     gc.collect()
     torch.cuda.empty_cache()
@@ -156,6 +159,7 @@ def run_benchmark(
     n_iter,
     verbose_run=False,
     verbose_summary=True,
+    verbose_output=False,
     input_audio_waveform=None,
 ):
     # Print parameters in one line

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -1,4 +1,5 @@
 import gc
+import os
 import time
 import torch
 import argparse
@@ -13,8 +14,19 @@ from configs import (
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
 
 
+def valid_input_audio_file(file):
+    ext = os.path.splitext(file)[1]
+    if ext.lower() != ".mp3":
+        raise argparse.ArgumentTypeError(
+            f"The audio file must be in .mp3 format, but got '{ext}'"
+        )
+    return file
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Run Whisper performance benchmark")
+
+    # Add test scenario
     parser.add_argument(
         "-s",
         "--test-scenario",
@@ -23,6 +35,16 @@ def parse_args():
         choices=WHISPER_PERF_BENCHMARK_CONFIG_DICT.keys(),
         help="Test scenario to run",
     )
+
+    # Add optional audio file in mp3 format
+    parser.add_argument(
+        "-a",
+        "--audio-file",
+        type=valid_input_audio_file,
+        default=None,
+        help="Path to audio file in mp3 format",
+    )
+
     return parser.parse_args()
 
 

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -133,6 +133,8 @@ def run_benchmark(
     n_iter,
     verbose_run=False,
     verbose_summary=True,
+    input_audio_waveform=None,
+    input_audio_sampling_rate=None,
 ):
     # Print parameters in one line
     if verbose_summary:
@@ -152,21 +154,24 @@ def run_benchmark(
     throughput_generation_list = []
 
     # Input waveform
-    ds = load_dataset(
-        "hf-internal-testing/librispeech_asr_dummy",
-        "clean",
-        split="validation",
-        trust_remote_code=True,
-    )
-    audio_sample = ds[0]["audio"]
-    waveform = audio_sample["array"]
-    sampling_rate = audio_sample["sampling_rate"]
-
-    # Make batch
-    batch_waveform = [
-        waveform + np.random.normal(0, np.std(waveform) * 2, len(waveform))
-        for _ in range(batch_size)
-    ]
+    if not input_audio_waveform:
+        ds = load_dataset(
+            "hf-internal-testing/librispeech_asr_dummy",
+            "clean",
+            split="validation",
+            trust_remote_code=True,
+        )
+        audio_sample = ds[0]["audio"]
+        waveform = audio_sample["array"]
+        sampling_rate = audio_sample["sampling_rate"]
+        batch_waveform = [
+            waveform + np.random.normal(0, np.std(waveform) * 2, len(waveform))
+            for _ in range(batch_size)
+        ]
+    else:
+        waveform = input_audio_waveform
+        sampling_rate = input_audio_sampling_rate
+        batch_waveform = [waveform for _ in range(batch_size)]
 
     # Start benchmarking
     for _ in range(n_iter):

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -126,7 +126,7 @@ def run_model(
     time_start_output_decoding = time.perf_counter()
     processor.batch_decode(outputs)
     time_end_output_decoding = time.perf_counter()
-    print(processor.batch_decode(outputs) + "\n")
+    print(processor.batch_decode(outputs), end="\n\n")
     time_output_decoding = time_end_output_decoding - time_start_output_decoding
 
     # Clean up memory

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -126,6 +126,7 @@ def run_model(
     time_start_output_decoding = time.perf_counter()
     processor.batch_decode(outputs)
     time_end_output_decoding = time.perf_counter()
+    print(processor.batch_decode(outputs) + "\n")
     time_output_decoding = time_end_output_decoding - time_start_output_decoding
 
     # Clean up memory

--- a/whisper-benchmark.py
+++ b/whisper-benchmark.py
@@ -175,7 +175,7 @@ def run_benchmark(
     throughput_generation_list = []
 
     # Input waveform
-    if not input_audio_waveform:
+    if input_audio_waveform is None:
         ds = load_dataset(
             "hf-internal-testing/librispeech_asr_dummy",
             "clean",


### PR DESCRIPTION
This pull request primarily focuses on enhancing the functionality of the `whisper-benchmark.py` script by adding the ability to use a custom audio file as input for the Whisper benchmarking process. The changes also include a modification in the `configs.py` file to adjust the batch size for the `whisper-large-v3-test` model. 

Here are the key changes:

Custom Audio Input:
* [`whisper-benchmark.py`](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R19-R51): Added a function `valid_input_audio_file(file)` to validate the input audio file format.
* [`whisper-benchmark.py`](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R60-R69): Extended the `parse_args()` function to include an optional argument for providing an audio file in mp3 format.
* [`whisper-benchmark.py`](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R78): Modified the `run_model()` function to include a verbose output option. The decoded outputs are printed if this option is enabled. [[1]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R78) [[2]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718L83-R139)
* [`whisper-benchmark.py`](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R162-R163): Updated the `run_benchmark()` function to accept an `input_audio_waveform` argument. If no waveform is provided, the function defaults to the existing dataset. [[1]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R162-R163) [[2]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R183) [[3]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718L142-R200)
* [`whisper-benchmark.py`](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R305-R310): In the `run_all_benchmark(test_scenario)` function, added a section to load the audio file if provided and pass the extracted waveform to the `run_benchmark()` function. [[1]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R305-R310) [[2]](diffhunk://#diff-a20942894802db9bc808284010cb6ecb439bf28ea4632da06ff596824d2c8718R319)

Model Configuration:
* [`configs.py`](diffhunk://#diff-c5d13c0f25b00c1ced8b97504fcadf314555c353092b9b584aeda64a108f7237L51-R51): Reduced the batch size for the `whisper-large-v3-test` model from 192 to 2.